### PR TITLE
docs: add core and utils api docs

### DIFF
--- a/docs/api/core/SUSPENSE.md
+++ b/docs/api/core/SUSPENSE.md
@@ -1,0 +1,17 @@
+---
+id: suspense
+title: SUSPENSE
+sidebar_label: SUSPENSE
+---
+
+`SUSPENSE` is a special symbol that can be emitted from observables to let the react hook
+know that there is a value on its way, and that we want to leverage React Suspense
+while we are waiting for that value.
+
+---
+
+```ts
+const story$ = selectedStoryId$.pipe(
+  switchMap((id) => concat(SUSPENSE, getStory$(id))),
+)
+```

--- a/docs/api/core/Subscribe.md
+++ b/docs/api/core/Subscribe.md
@@ -1,0 +1,17 @@
+---
+id: subscribe
+title: <Subscribe />
+sidebar_label: <Subscribe />
+---
+
+A React Component that creates a subscription to the provided observable once
+the component mounts, and unsubscribes when the component unmounts.
+
+Properties:
+
+- `source$`: Source observable that the Component will subscribe to.
+- `graceTime`: an optional property that describes the amount of time in ms
+  that the Component should wait before unsubscribing from the source observable
+  after it unmounts (default = 200).
+
+Important: This Component doesn't trigger any updates.

--- a/docs/api/core/bind.md
+++ b/docs/api/core/bind.md
@@ -1,7 +1,7 @@
 ---
 id: bind
-title: bind
-sidebar_label: bind
+title: bind()
+sidebar_label: bind()
 ---
 
 Creates a hook and its respective shared stream from an observable or factory of observables.

--- a/docs/api/core/shareLatest.md
+++ b/docs/api/core/shareLatest.md
@@ -1,7 +1,7 @@
 ---
 id: share-latest
-title: shareLatest
-sidebar_label: shareLatest
+title: shareLatest()
+sidebar_label: shareLatest()
 ---
 
 A RxJS pipeable operator which multicasts the source stream and replays the
@@ -17,7 +17,7 @@ const activePlanetName$ = planet$.pipe(
 );
 ```
 
-The enhanced observables returned from `bind` have been enhanced with this operator.
+The observables returned from `bind` have been enhanced with this operator.
 
 It's similar to RxJS's `shareReplay({ refCount: true, bufferSize: 1 })`, but
 with one difference: If the source stream completes or errors, `shareReplay`

--- a/docs/api/core/useSubscribe.md
+++ b/docs/api/core/useSubscribe.md
@@ -1,0 +1,16 @@
+---
+id: use-subscribe
+title: useSubscribe()
+sidebar_label: useSubscribe()
+---
+
+A React hook that creates a subscription to the provided observable once the
+component mounts and it unsubscribes when the component unmounts.
+
+Arguments:
+
+- `source$`: Source observable that the hook will subscribe to.
+- `unsubscribeGraceTime`: Amount of time in ms that the hook should wait before
+  unsubscribing from the source observable after it unmounts (default = 200).
+
+Important: This hook doesn't trigger any updates.

--- a/docs/api/utils/collect.md
+++ b/docs/api/utils/collect.md
@@ -1,0 +1,14 @@
+---
+id: collect
+title: collect()
+sidebar_label: collect()
+---
+
+A pipeable operator that collects all the GroupedObservables emitted by
+the source and emits a Map with the active inner observables.
+
+### Arguments
+
+- `filter?`: A function that receives the inner Observable and returns an
+  Observable of boolean values, which indicates whether the inner observable
+  should be collected.

--- a/docs/api/utils/collectValues.md
+++ b/docs/api/utils/collectValues.md
@@ -1,0 +1,57 @@
+---
+id: collect-values
+title: collectValues()
+sidebar_label: collectValues()
+---
+
+A pipeable operator that collects all the GroupedObservables emitted by
+the source and emits a Map with the latest values of the inner observables.
+
+### Example
+
+```ts
+const votesByKey$ = new Subject<{ key: string }>()
+const counters$ = votesByKey$.pipe(
+  split(
+    (vote) => vote.key,
+    (votes$) =>
+      votes$.pipe(
+        mapTo(1),
+        scan((count) => count + 1),
+        takeWhile((count) => count < 3),
+      ),
+  ),
+  collectValues(),
+)
+
+counters$.subscribe((counters) => {
+  console.log("counters$:")
+  counters.forEach((value, key) => {
+    console.log(`${key}: ${value}`)
+  })
+})
+
+votesByKey$.next({ key: "foo" })
+// > counters$:
+// > foo: 1
+
+votesByKey$.next({ key: "foo" })
+// > counters$:
+// > foo: 2
+
+votesByKey$.next({ key: "bar" })
+// > counters$:
+// > foo: 2
+// > bar: 1
+
+votesByKey$.next({ key: "foo" })
+// > counters$:
+// > bar: 1
+
+votesByKey$.next({ key: "bar" })
+// > counters$:
+// > bar: 2
+//
+votesByKey$.next({ key: "bar" })
+// > counters$:
+```

--- a/docs/api/utils/mergeWithKey.md
+++ b/docs/api/utils/mergeWithKey.md
@@ -1,0 +1,40 @@
+---
+id: merge-with-key
+title: mergeWithKey()
+sidebar_label: mergeWithKey()
+---
+
+Emits the values from all the streams of the provided object, in a result
+which provides the key of the stream of that emission.
+
+### Arguments
+
+- `inputObject`: Object of streams
+
+### Example
+
+```ts
+const inc$ = new Subject()
+const dec$ = new Subject()
+const resetTo$ = new Subject<number>()
+
+const counter$ = mergeWithKey({
+  inc$,
+  dec$,
+  resetTo$,
+}).pipe(
+  scan((acc, current) => {
+    switch (current.type) {
+      case "inc$":
+        return acc + 1
+      case "dec$":
+        return acc - 1
+      case "resetTo$":
+        return current.payload
+      default:
+        return acc
+    }
+  }, 0),
+  startWith(0),
+)
+```

--- a/docs/api/utils/selfDependant.md
+++ b/docs/api/utils/selfDependant.md
@@ -1,0 +1,28 @@
+---
+id: self-dependant
+title: selfDepandant()
+sidebar_label: selfDepandant()
+---
+
+A creation operator that helps creating observables that have circular
+dependencies.
+
+### Example
+
+```ts
+const [_resetableCounter$, connectResetableCounter] = selfDependant<number>()
+
+const clicks$ = new Subject()
+const inc$ = clicks$.pipe(
+  withLatestFrom(_resetableCounter$),
+  map((_, x) => x + 1),
+  share(),
+)
+
+const delayedZero$ = of(0).pipe(delay(10_000))
+const reset$ = inc$.pipe(switchMapTo(delayedZero$))
+
+const resetableCounter$ = merge(inc$, reset$, of(0)).pipe(
+  connectResetableCounter(),
+)
+```

--- a/docs/api/utils/split.md
+++ b/docs/api/utils/split.md
@@ -1,0 +1,19 @@
+---
+id: split
+title: split()
+sidebar_label: split()
+---
+
+A RxJS operator that groups the items emitted by the source based on the
+keySelector function, emitting one Observable for each group.
+
+### Arguments
+
+- `keySelector`: A function that receives an item and returns the key of that
+  item's group.
+- `streamSelector`: (optional) The function to apply to each group observable
+  (default = identity).
+
+`split` will subscribe to each group observable and share the result to every
+inner subscriber of that group. This inner observable can be mapped to another
+observable through the `streamSelector` argument.

--- a/docs/api/utils/suspend.md
+++ b/docs/api/utils/suspend.md
@@ -1,0 +1,15 @@
+---
+id: suspend
+title: suspend()
+sidebar_label: suspend()
+---
+
+A RxJS creation operator that prepends a `SUSPENSE` to the source observable.
+
+### Example
+
+```ts
+const story$ = selectedStoryId$.pipe(
+  switchMap(id => suspend(getStory$(id))
+)
+```

--- a/docs/api/utils/suspended.md
+++ b/docs/api/utils/suspended.md
@@ -1,0 +1,15 @@
+---
+id: suspended
+title: suspended()
+sidebar_label: suspended()
+---
+
+The pipeable version of `suspend`.
+
+### Example
+
+```ts
+const story$ = selectedStoryId$.pipe(
+  switchMap((id) => getStory$(id).pipe(suspended())),
+)
+```

--- a/docs/api/utils/switchMapSuspended.md
+++ b/docs/api/utils/switchMapSuspended.md
@@ -1,0 +1,13 @@
+---
+id: switch-map-suspended
+title: switchMapSuspended()
+sidebar_label: switchMapSuspended()
+---
+
+Like `switchMap` but applying a `startWith(SUSPENSE)` to the inner observable.
+
+### Example
+
+```ts
+const story$ = selectedStoryId$.pipe(switchMapSuspended(getStory$))
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,21 +1,40 @@
 module.exports = {
   someSidebar: {
     Introduction: [
+      "introduction/getting-started",
       "introduction/motivation",
       "introduction/core-concepts",
-      "introduction/getting-started",
     ],
     Tutorial: [
       "tutorial/intro",
       "tutorial/basic"
     ],
     "API Reference": [
-      "api/core/bind",
-      "api/core/share-latest",
+      {
+        "type": "category",
+        "label": "Core",
+        "items": [
+
+          "api/core/bind",
+          "api/core/share-latest",
+          "api/core/suspense",
+          "api/core/use-subscribe",
+          "api/core/subscribe",
+        ]
+      },
       {
         "type": "category",
         "label": "Utils",
-        "items": []
+        "items": [
+          "api/utils/collect",
+          "api/utils/collect-values",
+          "api/utils/merge-with-key",
+          "api/utils/self-dependant",
+          "api/utils/split",
+          "api/utils/suspend",
+          "api/utils/suspended",
+          "api/utils/switch-map-suspended",
+        ]
       }
     ],
   },


### PR DESCRIPTION
- add remaining api docs from core
- add api docs from utils
- change api docs to have round/angle brackets to distinguish fuctions and components (similar to recoil docs)
- move getting started to top of doc tree
- put core docs in sub-category

I have decided on reflection to use a sub-category for core docs, here are some comparisons:

![image](https://user-images.githubusercontent.com/3295115/91841574-84ebc380-ec4a-11ea-9763-ae39cf58170e.png)

![image](https://user-images.githubusercontent.com/3295115/91841595-8d43fe80-ec4a-11ea-82d6-9c9bb519b839.png)

![image](https://user-images.githubusercontent.com/3295115/91841628-992fc080-ec4a-11ea-91a9-79f61980263e.png)

![image](https://user-images.githubusercontent.com/3295115/91841710-b795bc00-ec4a-11ea-8c28-c852a938beda.png)

