### PR TITLE
docs(utils): api improvements

### DIFF
--- a/docs/api/core/bind.md
+++ b/docs/api/core/bind.md
@@ -3,7 +3,7 @@ title: bind(observable)
 sidebar_label: bind()
 ---
 
-Binds an observable to React, and returns a hook and shared stream representing the source observable.
+Binds an Observable to React, and returns a hook and shared stream representing the source Observable.
 
 ```ts
 function bind<T>(observable: Observable<T>): 
@@ -12,19 +12,19 @@ function bind<T>(observable: Observable<T>):
 
 #### Arguments
 
-- `observable`: Source observable to be used by the hook.
+- `observable`: The source Observable to be used by the hook.
 
 #### Returns
 
 `[1, 2]`:
 
-1. A React Hook that yields the latest emitted value of the observable. If the
+1. A React Hook that yields the latest emitted value of the Observable. If the
    Observable doesn't synchronously emit a value upon the first subscription, then
    the hook will leverage React Suspense while it's waiting for the first value.
 
-2. A [`shareLatest`] version of the observable. It can be used for composing other
+2. A [`shareLatest`] version of the source Observable. It can be used for composing other
    streams that depend on it. The shared subscription is closed as soon as there
-   are no subscribers to that observable.
+   are no subscribers to that Observable.
 
 ### Example
 
@@ -48,7 +48,7 @@ function CounterDisplay() {
 
 ## Factory Overload
 
-Binds an observable factory function to React, and returns a hook and shared stream representing the created observables.
+Binds an Observable factory function to React, and returns a hook and shared stream representing the created Observables.
 
 ```ts
 function bind<A extends unknown[], O>(getObservable: (...args: A) => Observable<O>): 
@@ -57,7 +57,7 @@ function bind<A extends unknown[], O>(getObservable: (...args: A) => Observable<
 
 #### Arguments
 
-- `getObservable`: Factory of observables. The arguments of this function 
+- `getObservable`: Factory of Observables. The arguments of this function 
    will be the ones used in the hook.
 
 #### Returns
@@ -65,13 +65,13 @@ function bind<A extends unknown[], O>(getObservable: (...args: A) => Observable<
 `[1, 2]`:
 
 1. A React hook with the same arguments as the factory function. This hook
-   will yield the latest update from the observable returned from the factory function.
+   will yield the latest update from the Observable returned from the factory function.
    If the Observable doesn't synchronously emit a value upon the first subscription, then
    the hook will leverage React Suspense while it's waiting for the first value.
 
-2. A [`shareLatest`] version of the observable returned by the factory function. It
+2. A [`shareLatest`] version of the Observable returned by the factory function. It
    can be used for composing other streams that depend on it. The shared subscription
-   is closed as soon as there are no subscribers to that observable.
+   is closed as soon as there are no subscribers to that Observable.
 
 
 ### Example
@@ -95,7 +95,6 @@ const Story: React.FC<{ id: number }> = ({ id }) => {
 
 ## See also
 
-* [`shareLatest()`]
+* [`shareLatest()`](shareLatest)
 
 [`shareLatest`]: shareLatest
-[`shareLatest()`]: shareLatest

--- a/docs/api/core/shareLatest.md
+++ b/docs/api/core/shareLatest.md
@@ -2,7 +2,7 @@
 title: shareLatest()
 ---
 
-An RxJS pipeable operator which multicasts the source stream and replays the
+An RxJS [pipeable operator] which multicasts the source stream and replays the
 latest emitted value.
 
 ```ts
@@ -11,12 +11,12 @@ function shareLatest<T>(): MonoTypeOperatorFunction<T>
 
 #### Returns
 
-[`MonoTypeOperatorFunction<T>`]: An observable that shares the latest emitted value from the 
-source observable with all subscribers, and restarts the stream when it completes or errors.
+[`MonoTypeOperatorFunction<T>`]: An Observable that shares the latest emitted value from the 
+source Observable with all subscribers, and restarts the stream when it completes or errors.
 
 ### Description
 
-The observables returned from [`bind`] have been enhanced with this operator.
+The Observables returned from [`bind`] have been enhanced with this operator.
 
 It's similar to RxJS's `shareReplay({ refCount: true, bufferSize: 1 })`, but
 with one difference: If the source stream completes or errors, `shareReplay`
@@ -44,4 +44,4 @@ const activePlanetName$ = planet$.pipe(
 [`bind`]: bind
 [`shareReplay`]: https://rxjs-dev.firebaseapp.com/api/operators/shareReplay
 [`MonoTypeOperatorFunction<T>`]: https://rxjs-dev.firebaseapp.com/api/index/interface/MonoTypeOperatorFunction
-
+[pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators

--- a/docs/api/core/shareLatest.md
+++ b/docs/api/core/shareLatest.md
@@ -39,7 +39,7 @@ const activePlanetName$ = planet$.pipe(
 
 ## See also
 * [`bind`]
-* [`shareReplay`] (RxJs)
+* [`shareReplay`] (RxJS)
 
 [`bind`]: bind
 [`shareReplay`]: https://rxjs-dev.firebaseapp.com/api/operators/shareReplay

--- a/docs/api/core/subscribe.md
+++ b/docs/api/core/subscribe.md
@@ -16,7 +16,7 @@ const Subscribe: React.FC<{
 #### Properties
 
 - `source$`: Source observable that the Component will subscribe to.
-- `fallback`: (Optional, default = `null`) The JSX Element to be rendered 
+- `fallback`: (Optional, default = `null`). The JSX Element to be rendered 
 before the subscription is created.
 
 :::note Important

--- a/docs/api/core/subscribe.md
+++ b/docs/api/core/subscribe.md
@@ -3,7 +3,7 @@ id: subscribe
 title: <Subscribe />
 ---
 
-A React Component that creates a subscription to the provided observable once
+A React Component that creates a subscription to the provided Observable once
 the component mounts, and unsubscribes when the component unmounts.
 
 ```tsx
@@ -15,7 +15,7 @@ const Subscribe: React.FC<{
 
 #### Properties
 
-- `source$`: Source observable that the Component will subscribe to.
+- `source$`: Source Observable that the Component will subscribe to.
 - `fallback`: (Optional, default = `null`). The JSX Element to be rendered 
 before the subscription is created.
 

--- a/docs/api/core/subscribe.md
+++ b/docs/api/core/subscribe.md
@@ -16,7 +16,7 @@ const Subscribe: React.FC<{
 #### Properties
 
 - `source$`: Source observable that the Component will subscribe to.
-- `fallback`: Optional, defaults to `null`. The JSX Element to be rendered 
+- `fallback`: (Optional, default = `null`) The JSX Element to be rendered 
 before the subscription is created.
 
 :::note Important

--- a/docs/api/core/useSubscribe.md
+++ b/docs/api/core/useSubscribe.md
@@ -3,16 +3,16 @@ title: useSubscribe(observable)
 sidebar_label: useSubcribe()
 ---
 
-A React hook that creates a subscription to the provided observable once the
+A React hook that creates a subscription to the provided Observable once the
 component mounts and it unsubscribes when the component unmounts.
 
 ```ts
-function useSubscribe<T>(source$: Observable<T>) => void;
+function useSubscribe<T>(source$: Observable<T>): void;
 ```
 
 #### Arguments
 
-- `source$`: Source observable that the hook will subscribe to.
+- `source$`: Source Observable that the hook will subscribe to.
 
 :::note Important
 This hook doesn't trigger any updates.

--- a/docs/api/utils/collect.md
+++ b/docs/api/utils/collect.md
@@ -1,12 +1,29 @@
 ---
-title: collect()
+title: collect(filter)
+sidebar_label: collect()
 ---
 
-A pipeable operator that collects all the GroupedObservables emitted by
-the source and emits a Map with the active inner observables.
+A [pipeable operator] that collects all the [`GroupedObservable`]s emitted by
+the source and emits a `Map` with the active inner observables.
 
-### Arguments
+```ts
+function collect<K, V>(filter?: (grouped: GroupedObservable<K, V>) => Observable<boolean>): 
+  OperatorFunction<GroupedObservable<K, V>, Map<K, GroupedObservable<K, V>>>
+```
 
-- `filter?`: A function that receives the inner Observable and returns an
-  Observable of boolean values, which indicates whether the inner observable
-  should be collected.
+#### Arguments
+
+- `filter?`: (Optional, default = undefined) A function that receives the inner 
+  Observable and returns an Observable of boolean values, which indicates 
+  whether the inner observable should be collected.
+
+#### Returns
+
+`OperatorFunction<GroupedObservable<K, V>, Map<K, GroupedObservable<K, V>>>`: **TODO**
+
+## See also
+* [`collectValues()`](collectValues)
+* [`split(keySelector)`](split)
+
+[pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
+[`GroupedObservable`]: https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable

--- a/docs/api/utils/collect.md
+++ b/docs/api/utils/collect.md
@@ -15,7 +15,7 @@ function collect<K, V>(filter?: (grouped: GroupedObservable<K, V>) => Observable
 
 - `filter?`: (Optional, default = undefined). A function that receives the inner 
   Observable and returns an Observable of boolean values, which indicates 
-  whether the inner observable should be collected.
+  whether the inner Observable should be collected.
 
 #### Returns
 

--- a/docs/api/utils/collect.md
+++ b/docs/api/utils/collect.md
@@ -13,13 +13,15 @@ function collect<K, V>(filter?: (grouped: GroupedObservable<K, V>) => Observable
 
 #### Arguments
 
-- `filter?`: (Optional, default = undefined) A function that receives the inner 
+- `filter?`: (Optional, default = undefined). A function that receives the inner 
   Observable and returns an Observable of boolean values, which indicates 
   whether the inner observable should be collected.
 
 #### Returns
 
-`OperatorFunction<GroupedObservable<K, V>, Map<K, GroupedObservable<K, V>>>`: **TODO**
+[`OperatorFunction<GroupedObservable<K, V>, Map<K, GroupedObservable<K, V>>>`][OperatorFunction]: An Observable that 
+emits a `Map` containing all the keys seen in the source grouped Observables so far, along with the grouped Observable
+for matches each key.
 
 ## See also
 * [`collectValues()`](collectValues)
@@ -27,3 +29,4 @@ function collect<K, V>(filter?: (grouped: GroupedObservable<K, V>) => Observable
 
 [pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
 [`GroupedObservable`]: https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable
+[OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/collectValues.md
+++ b/docs/api/utils/collectValues.md
@@ -3,7 +3,7 @@ title: collectValues()
 ---
 
 A [pipeable operator] that collects all the [`GroupedObservable`]s emitted by
-the source and emits a `Map` with the latest values of the inner observables.
+the source and emits a `Map` with the latest values of the inner Observables.
 
 ```ts
 function collectValues<K, V>(): OperatorFunction<GroupedObservable<K, V>, Map<K, V>>
@@ -11,7 +11,8 @@ function collectValues<K, V>(): OperatorFunction<GroupedObservable<K, V>, Map<K,
 
 #### Returns
 
-`OperatorFunction<GroupedObservable<K, V>, Map<K, V>>`: **TODO**
+[`OperatorFunction<GroupedObservable<K, V>, Map<K, V>>`][OperatorFunction]: An Observable that 
+emits a `Map` with the latest value for each key in the source grouped Observables.
 
 ### Example
 
@@ -72,3 +73,4 @@ votesByKey$.next({ key: "bar" })
 
 [pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
 [`GroupedObservable`]: https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable
+[OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/collectValues.md
+++ b/docs/api/utils/collectValues.md
@@ -2,12 +2,24 @@
 title: collectValues()
 ---
 
-A pipeable operator that collects all the GroupedObservables emitted by
-the source and emits a Map with the latest values of the inner observables.
+A [pipeable operator] that collects all the [`GroupedObservable`]s emitted by
+the source and emits a `Map` with the latest values of the inner observables.
+
+```ts
+function collectValues<K, V>(): OperatorFunction<GroupedObservable<K, V>, Map<K, V>>
+```
+
+#### Returns
+
+`OperatorFunction<GroupedObservable<K, V>, Map<K, V>>`: **TODO**
 
 ### Example
 
 ```ts
+import { Subject } from 'rxjs'
+import { mapTo, scan, takeWhile } from 'rxjs/operators'
+import { collectValues, split } from '@react-rxjs/utils'
+
 const votesByKey$ = new Subject<{ key: string }>()
 const counters$ = votesByKey$.pipe(
   split(
@@ -53,3 +65,10 @@ votesByKey$.next({ key: "bar" })
 votesByKey$.next({ key: "bar" })
 // > counters$:
 ```
+
+## See also
+* [`collect(filter)`](collect)
+* [`split(keySelector)`](split)
+
+[pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
+[`GroupedObservable`]: https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable

--- a/docs/api/utils/mergeWithKey.md
+++ b/docs/api/utils/mergeWithKey.md
@@ -1,17 +1,40 @@
 ---
-title: mergeWithKey()
+title: mergeWithKey(inputObject)
+sidebar_label: mergeWithKey()
 ---
 
 Emits the values from all the streams of the provided object, in a result
 which provides the key of the stream of that emission.
 
-### Arguments
+```ts
+function mergeWithKey<
+  O extends { [P in keyof any]: ObservableInput<any> },
+  OT extends {
+    [K in keyof O]: O[K] extends ObservableInput<infer V>
+      ? { type: K; payload: V }
+      : unknown
+  }
+>(inputObject: O, concurrent?: number, scheduler?: SchedulerLike): 
+  Observable<OT[keyof O]>
+```
+
+#### Arguments
 
 - `inputObject`: Object of streams
+- `concurrent`: (Optional) **TODO**
+- `scheduler`: (Optional) **TODO**
+
+#### Returns
+
+`Observable<OT[keyof O]>`: **TODO**
 
 ### Example
 
 ```ts
+import { Subject } from "rxjs"
+import { scan, startWith } from 'rxjs/operators'
+import { mergeWithKey } from '@react-rxjs/utils'
+
 const inc$ = new Subject()
 const dec$ = new Subject()
 const resetTo$ = new Subject<number>()

--- a/docs/api/utils/selfDependant.md
+++ b/docs/api/utils/selfDependant.md
@@ -2,17 +2,32 @@
 title: selfDependant()
 ---
 
-A creation operator that helps creating observables that have circular
-dependencies.
+An RxJS creation operator for observables that have circular dependencies.
+
+```ts
+function selfDependant<T>(): [Observable<T>, () => MonoTypeOperatorFunction<T>];
+```
+
+#### Returns
+
+`[1, 2]`:
+
+1. An observable... (**TODO**)
+
+2. A pipeable operator... (**TODO**)
 
 ### Example
 
 ```ts
-const [_resetableCounter$, connectResetableCounter] = selfDependant<number>()
+import { merge, of, Subject } from 'rxjs'
+import { delay, map, share, switchMapTo, withLatestFrom } from 'rxjs/operators'
+import { selfDependant } from '@react-rxjs/utils'
+
+const [_resettableCounter$, connectResettableCounter] = selfDependant<number>()
 
 const clicks$ = new Subject()
 const inc$ = clicks$.pipe(
-  withLatestFrom(_resetableCounter$),
+  withLatestFrom(_resettableCounter$),
   map((_, x) => x + 1),
   share(),
 )
@@ -20,7 +35,7 @@ const inc$ = clicks$.pipe(
 const delayedZero$ = of(0).pipe(delay(10_000))
 const reset$ = inc$.pipe(switchMapTo(delayedZero$))
 
-const resetableCounter$ = merge(inc$, reset$, of(0)).pipe(
-  connectResetableCounter(),
+const resettableCounter$ = merge(inc$, reset$, of(0)).pipe(
+  connectResettableCounter(),
 )
 ```

--- a/docs/api/utils/selfDependant.md
+++ b/docs/api/utils/selfDependant.md
@@ -12,7 +12,7 @@ function selfDependant<T>(): [Observable<T>, () => MonoTypeOperatorFunction<T>];
 
 `[1, 2]`:
 
-1. An observable... (**TODO**)
+1. An Observable... (**TODO**)
 
 2. A pipeable operator... (**TODO**)
 

--- a/docs/api/utils/split.md
+++ b/docs/api/utils/split.md
@@ -19,19 +19,18 @@ function split<T, K>(keySelector: (value: T) => K, streamSelector?: (grouped: Ob
 #### Returns
 
 [`OperatorFunction<T, GroupedObservable<K, T>>`][OperatorFunction]: An Observable that emits a grouped Observable for each key
-provided by the key selector function. The values from the source observable emitted in each grouped Observable 
+provided by the key selector function. The values from the source Observable emitted in each grouped Observable 
 are optional transformed by the stream selector function, if specified.
 
 ### Description
 
-`split` will subscribe to each group observable and share the result to every
-inner subscriber of that group. This inner observable can be mapped to another
-observable through the `streamSelector` argument.
+`split` will subscribe to each grouped Observable and share the result to every
+inner subscriber of that group. This inner Observable can be mapped to another
+Observable through the `streamSelector` argument.
 
 ## See also
 * [`collect(filter)`](collect)
 * [`collectValues()`](collectValues)
-* [`GroupedObservable`](https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable) (RxJS)
 
 [pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
 [OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/split.md
+++ b/docs/api/utils/split.md
@@ -3,7 +3,7 @@ title: split(keySelector)
 sidebar_label: split()
 ---
 
-An RxJS operator that groups the items emitted by the source based on the
+A [pipeable operator] that groups the items emitted by the source based on the
 `keySelector` function, emitting one Observable for each group.
 
 ```ts
@@ -13,13 +13,14 @@ function split<T, K>(keySelector: (value: T) => K, streamSelector?: (grouped: Ob
 
 #### Arguments
 
-- `keySelector`: A function that receives an item and returns the key of that
-  item's group.
-- `streamSelector`: (Optional, default = identity). The function to apply to each group observable.
+- `keySelector`: A function that receives an item and returns the key of that item's group.
+- `streamSelector`: (Optional, default = identity). The function to apply to each grouped Observable.
 
 #### Returns
 
-**TODO**
+[`OperatorFunction<T, GroupedObservable<K, T>>`][OperatorFunction]: An Observable that emits a grouped Observable for each key
+provided by the key selector function. The values from the source observable emitted in each grouped Observable 
+are optional transformed by the stream selector function, if specified.
 
 ### Description
 
@@ -30,3 +31,7 @@ observable through the `streamSelector` argument.
 ## See also
 * [`collect(filter)`](collect)
 * [`collectValues()`](collectValues)
+* [`GroupedObservable`](https://rxjs-dev.firebaseapp.com/api/index/class/GroupedObservable) (RxJS)
+
+[pipeable operator]: https://rxjs.dev/guide/v6/pipeable-operators
+[OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/split.md
+++ b/docs/api/utils/split.md
@@ -1,17 +1,32 @@
 ---
-title: split()
+title: split(keySelector)
+sidebar_label: split()
 ---
 
-A RxJS operator that groups the items emitted by the source based on the
-keySelector function, emitting one Observable for each group.
+An RxJS operator that groups the items emitted by the source based on the
+`keySelector` function, emitting one Observable for each group.
 
-### Arguments
+```ts
+function split<T, K>(keySelector: (value: T) => K, streamSelector?: (grouped: Observable<T>, key: K) => Observable<R>): 
+  OperatorFunction<T, GroupedObservable<K, T>>
+```
+
+#### Arguments
 
 - `keySelector`: A function that receives an item and returns the key of that
   item's group.
-- `streamSelector`: (optional) The function to apply to each group observable
-  (default = identity).
+- `streamSelector`: (Optional, default = identity). The function to apply to each group observable.
+
+#### Returns
+
+**TODO**
+
+### Description
 
 `split` will subscribe to each group observable and share the result to every
 inner subscriber of that group. This inner observable can be mapped to another
 observable through the `streamSelector` argument.
+
+## See also
+* [`collect(filter)`](collect)
+* [`collectValues()`](collectValues)

--- a/docs/api/utils/suspend.md
+++ b/docs/api/utils/suspend.md
@@ -1,13 +1,35 @@
 ---
-title: suspend()
+title: suspend(observable)
 ---
 
-A RxJS creation operator that prepends a `SUSPENSE` to the source observable.
+A RxJS creation operator that prepends a [`SUSPENSE`] to the source observable.
+
+```ts
+function suspend<T>(source$: Observable<T>) => Observable<T | typeof SUSPEND>
+```
+
+#### Arguments
+
+**TODO**
+
+#### Returns
+
+**TODO**
 
 ### Example
 
 ```ts
+import { switchMap } from 'rxjs/operators'
+import { suspend } from '@react-rxjs/utils'
+
 const story$ = selectedStoryId$.pipe(
   switchMap(id => suspend(getStory$(id))
 )
 ```
+
+## See also
+* [`SUSPENSE`]
+* [`suspended`]
+
+[`SUSPENSE`]: ../core/suspense
+[`suspended`]: suspended

--- a/docs/api/utils/suspend.md
+++ b/docs/api/utils/suspend.md
@@ -9,12 +9,12 @@ function suspend<T>(source$: Observable<T>) => Observable<T | typeof SUSPEND>
 ```
 
 #### Arguments
-
-**TODO**
+* `source$`: The source Observable.
 
 #### Returns
 
-**TODO**
+`Observable<T | typeof SUSPEND>`: An Observable that emits [`SUSPENSE`] 
+as its first value, followed by the values from the source observable.
 
 ### Example
 

--- a/docs/api/utils/suspend.md
+++ b/docs/api/utils/suspend.md
@@ -5,15 +5,15 @@ title: suspend(observable)
 A RxJS creation operator that prepends a [`SUSPENSE`] to the source Observable.
 
 ```ts
-function suspend<T>(source$: Observable<T>) => Observable<T | typeof SUSPEND>
+function suspend<T>(source$: Observable<T>) => Observable<T | typeof SUSPENSE>
 ```
 
 #### Arguments
-* `source$`: The source observable.
+* `source$`: The source Observable.
 
 #### Returns
 
-`Observable<T | typeof SUSPEND>`: An Observable that emits [`SUSPENSE`] 
+`Observable<T | typeof SUSPENSE>`: An Observable that emits [`SUSPENSE`] 
 as its first value, followed by the values from the source Observable.
 
 ### Example

--- a/docs/api/utils/suspend.md
+++ b/docs/api/utils/suspend.md
@@ -2,19 +2,19 @@
 title: suspend(observable)
 ---
 
-A RxJS creation operator that prepends a [`SUSPENSE`] to the source observable.
+A RxJS creation operator that prepends a [`SUSPENSE`] to the source Observable.
 
 ```ts
 function suspend<T>(source$: Observable<T>) => Observable<T | typeof SUSPEND>
 ```
 
 #### Arguments
-* `source$`: The source Observable.
+* `source$`: The source observable.
 
 #### Returns
 
 `Observable<T | typeof SUSPEND>`: An Observable that emits [`SUSPENSE`] 
-as its first value, followed by the values from the source observable.
+as its first value, followed by the values from the source Observable.
 
 ### Example
 

--- a/docs/api/utils/suspended.md
+++ b/docs/api/utils/suspended.md
@@ -10,7 +10,8 @@ function suspended<T>(): OperatorFunction<T, T | typeof SUSPEND>
 
 #### Returns
 
-**TODO**
+[`OperatorFunction<T, T | typeof SUSPEND>`][OperatorFunction]: An Observable that emits [`SUSPENSE`] 
+as its first value, followed by the values from the source observable.
 
 ### Example
 
@@ -31,3 +32,4 @@ const story$ = selectedStoryId$.pipe(
 [`suspend`]: suspend
 [`SUSPENSE`]: ../core/suspense
 [pipeable]: https://rxjs.dev/guide/v6/pipeable-operators
+[OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/suspended.md
+++ b/docs/api/utils/suspended.md
@@ -2,7 +2,7 @@
 title: suspended()
 ---
 
-The [pipeable] version of [`suspend`]. Prepends a [`SUSPENSE`] to the source observable.
+The [pipeable] version of [`suspend`]. Prepends a [`SUSPENSE`] to the source Observable.
 
 ```ts
 function suspended<T>(): OperatorFunction<T, T | typeof SUSPEND>

--- a/docs/api/utils/suspended.md
+++ b/docs/api/utils/suspended.md
@@ -11,7 +11,7 @@ function suspended<T>(): OperatorFunction<T, T | typeof SUSPEND>
 #### Returns
 
 [`OperatorFunction<T, T | typeof SUSPEND>`][OperatorFunction]: An Observable that emits [`SUSPENSE`] 
-as its first value, followed by the values from the source observable.
+as its first value, followed by the values from the source Observable.
 
 ### Example
 
@@ -25,11 +25,10 @@ const story$ = selectedStoryId$.pipe(
 ```
 
 ## See also
-* [`suspend`]
 * [`SUSPENSE`]
-* [Pipeable Operators][pipeable] (RxJS)
+* [`suspend`]
 
-[`suspend`]: suspend
 [`SUSPENSE`]: ../core/suspense
+[`suspend`]: suspend
 [pipeable]: https://rxjs.dev/guide/v6/pipeable-operators
 [OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/suspended.md
+++ b/docs/api/utils/suspended.md
@@ -2,12 +2,32 @@
 title: suspended()
 ---
 
-The pipeable version of `suspend`.
+The [pipeable] version of [`suspend`]. Prepends a [`SUSPENSE`] to the source observable.
+
+```ts
+function suspended<T>(): OperatorFunction<T, T | typeof SUSPEND>
+```
+
+#### Returns
+
+**TODO**
 
 ### Example
 
 ```ts
+import { switchMap } from 'rxjs/operators'
+import { suspended } from '@react-rxjs/utils'
+
 const story$ = selectedStoryId$.pipe(
   switchMap((id) => getStory$(id).pipe(suspended())),
 )
 ```
+
+## See also
+* [`suspend`]
+* [`SUSPENSE`]
+* [Pipeable Operators][pipeable] (RxJS)
+
+[`suspend`]: suspend
+[`SUSPENSE`]: ../core/suspense
+[pipeable]: https://rxjs.dev/guide/v6/pipeable-operators

--- a/docs/api/utils/switchMapSuspended.md
+++ b/docs/api/utils/switchMapSuspended.md
@@ -2,7 +2,7 @@
 title: switchMapSuspended()
 ---
 
-Like [`switchMap`], but applying a [`startWith(SUSPENSE)`][`startWith`] to the inner observable.
+Like [`switchMap`], but applying a [`startWith(SUSPENSE)`][`startWith`] to the inner Observable.
 
 ```ts
 function switchMapSuspended<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): 

--- a/docs/api/utils/switchMapSuspended.md
+++ b/docs/api/utils/switchMapSuspended.md
@@ -2,10 +2,35 @@
 title: switchMapSuspended()
 ---
 
-Like `switchMap` but applying a `startWith(SUSPENSE)` to the inner observable.
+Like [`switchMap`], but applying a [`startWith(SUSPENSE)`][`startWith`] to the inner observable.
+
+```ts
+function switchMapSuspended<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): 
+    OperatorFunction<T, ObservedValueOf<O> | typeof SUSPENSE>;
+```
+
+#### Arguments
+* `project`: A function that, when applied to an item emitted by the source Observable, returns an Observable.
+
+#### Returns
+
+[`OperatorFunction<T, ObservedValueOf<O> | typeof SUSPENSE>`][`OperatorFunction`]: An Observable that emits the result of applying the projection function to each item emitted by the source Observable, and taking only the values from the most recently projected inner Observable, prepended with [`SUSPENSE`].
 
 ### Example
 
 ```ts
+import { switchMapSuspended } from '@react-rxjs/utils'
+
 const story$ = selectedStoryId$.pipe(switchMapSuspended(getStory$))
 ```
+
+## See also
+* [`SUSPENSE`]
+* [`switchMap`] (RxJS)
+* [Pipeable Operators] (RxJS)
+
+[`SUSPENSE`]: ../core/suspense
+[`switchMap`]: https://rxjs-dev.firebaseapp.com/api/operators/switchMap
+[`startWith`]: https://rxjs-dev.firebaseapp.com/api/operators/startWith
+[Pipeable Operators]: https://rxjs.dev/guide/v6/pipeable-operators
+[`OperatorFunction`]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction

--- a/docs/api/utils/switchMapSuspended.md
+++ b/docs/api/utils/switchMapSuspended.md
@@ -14,7 +14,9 @@ function switchMapSuspended<T, O extends ObservableInput<any>>(project: (value: 
 
 #### Returns
 
-[`OperatorFunction<T, ObservedValueOf<O> | typeof SUSPENSE>`][`OperatorFunction`]: An Observable that emits the result of applying the projection function to each item emitted by the source Observable, and taking only the values from the most recently projected inner Observable, prepended with [`SUSPENSE`].
+[`OperatorFunction<T, ObservedValueOf<O> | typeof SUSPENSE>`][OperatorFunction]: An Observable that emits the result 
+of applying the projection function to each item emitted by the source Observable, and taking only the values from 
+the most recently projected inner Observable, prepended with [`SUSPENSE`].
 
 ### Example
 
@@ -26,11 +28,9 @@ const story$ = selectedStoryId$.pipe(switchMapSuspended(getStory$))
 
 ## See also
 * [`SUSPENSE`]
-* [`switchMap`] (RxJS)
-* [Pipeable Operators] (RxJS)
+* [`switchMap`], [`startWith`] (RxJS)
 
 [`SUSPENSE`]: ../core/suspense
 [`switchMap`]: https://rxjs-dev.firebaseapp.com/api/operators/switchMap
 [`startWith`]: https://rxjs-dev.firebaseapp.com/api/operators/startWith
-[Pipeable Operators]: https://rxjs.dev/guide/v6/pipeable-operators
-[`OperatorFunction`]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction
+[OperatorFunction]: https://rxjs-dev.firebaseapp.com/api/index/interface/OperatorFunction


### PR DESCRIPTION
- add typings
- use headings
- fix a typo
- include imports in examples

Some arguments and return types are still marked as TODO and can be completed separately later:
- `mergeWithKey` arguments and return type
- `selfDependant` return type