### PR TITLE
change theme of code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,6 +84,10 @@ module.exports = {
       ],
       copyright: `Built with Docusaurus.`,
     },
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/vsDark'),
+    }
   },
   presets: [
     [


### PR DESCRIPTION
Currently we have for both light/dark the default palenight theme:

tsx
<img src="https://user-images.githubusercontent.com/5365487/92460397-3a2cf700-f1c8-11ea-9d54-9142fdfc211e.png" height="250" />

diff
<img src="https://user-images.githubusercontent.com/5365487/92460466-4c0e9a00-f1c8-11ea-8c38-f0a55f73aed2.png" height="250" />

I don't fully like the way it redners tsx, because the same colour is used for both keywords (const, function, etc.) and names.

With this change I'm picking Github for light mode and VSDark for dark mode:

tsx
<img src="https://user-images.githubusercontent.com/5365487/92461342-790f7c80-f1c9-11ea-8e81-06a3e2e7824f.png" height="250" />

diff
<img src="https://user-images.githubusercontent.com/5365487/92461517-ac520b80-f1c9-11ea-9957-f220b1372ffa.png" height="250" />

OceanicNext for dark mode also looks right for tsx blocks, but unfortunately it doesn't do very well for diffs :/
<img src="https://user-images.githubusercontent.com/5365487/92461878-0ce14880-f1ca-11ea-8bc2-221d7affe1c6.png" height="250" />

