### PR TITLE
Fixing syntax error in todos.md

### DIFF
--- a/docs/tutorial/todos.md
+++ b/docs/tutorial/todos.md
@@ -51,10 +51,10 @@ Which is basically the same as doing this (but a lot shorter, of course :smile:)
 
 ```tsx
 const todoActions$ = merge(
-  newTodo$.pipe(map(text, id) => ({
-    type: "add" as const
+  newTodo$.pipe(map((text, id) => ({
+    type: "add" as const,
     payload: { id, text },
-  })),
+  }))),
   editTodo$.pipe(map(payload => ({
     type: "edit" as const,
     payload,
@@ -138,7 +138,7 @@ And with this we are ready to start wiring things up.
 Let's start with the top-level component:
 
 ```tsx
-const [useTodos] = bind(todosMap$.pipe(map(todosMap => [...todosMap.values()])))
+const [useTodos] = bind(todosMap$.pipe(map(todosMap => Array.from(todosMap.values()))))
 
 function TodoList() {
   const todoList = useTodos()

--- a/docs/tutorial/todos.md
+++ b/docs/tutorial/todos.md
@@ -138,7 +138,7 @@ And with this we are ready to start wiring things up.
 Let's start with the top-level component:
 
 ```tsx
-const [useTodos] = bind(todosMap$.pipe(map(todosMap => Array.from(todosMap.values()))))
+const [useTodos] = bind(todosMap$.pipe(map(todosMap => [...todosMap.values()])))
 
 function TodoList() {
   const todoList = useTodos()


### PR DESCRIPTION
I noticed two small code issues while going through the tutorials:

First, a syntax error in `todoActions$`.

Second, a TypeScript warning in the definition of `useTodos`:
> Type 'IterableIterator<Todo>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.

Replacing `[...todosMap.values()]` with `Array.from(todosMap.values())` makes that warning go away without customising TypeScript from its default value.